### PR TITLE
chore: Update statuses parser to string literal

### DIFF
--- a/apps/dashboard/src/lib/search-params.ts
+++ b/apps/dashboard/src/lib/search-params.ts
@@ -1,4 +1,4 @@
-import { createSearchParamsCache, parseAsArrayOf, parseAsString, parseAsStringEnum } from 'nuqs/server'
+import { createSearchParamsCache, parseAsArrayOf, parseAsString, parseAsStringLiteral } from 'nuqs/server'
 
 // TICKET FILTERS
 export const statuses = ['unhandled', 'snoozed', 'starred', 'closed'] as const
@@ -6,7 +6,7 @@ export type Status = (typeof statuses)[number]
 
 export const ticketFiltersParsers = {
   q: parseAsString,
-  statuses: parseAsArrayOf(parseAsStringEnum<Status>([...statuses])),
+  statuses: parseAsArrayOf(parseAsStringLiteral(statuses)),
   assignees: parseAsArrayOf(parseAsString),
 }
 


### PR DESCRIPTION
While the enum parser works, this one requires fewer hoops to jump through when feeding an array of string literals.

Source: https://nuqs.47ng.com/docs/parsers#literals